### PR TITLE
Bug fix of getItemPath function in LDAPLookup class

### DIFF
--- a/src/main/java/org/cristalise/lookup/ldap/LDAPLookup.java
+++ b/src/main/java/org/cristalise/lookup/ldap/LDAPLookup.java
@@ -436,15 +436,17 @@ public class LDAPLookup implements LookupManager{
         	ItemPath item = new ItemPath(uuid);
             LDAPEntry anEntry=mLDAPAuth.getAuthObject().read(getDN(item)+mLocalPath,attr);
             String[] values = LDAPLookupUtils.getAllAttributeValues(anEntry, "objectclass");
+            boolean isItem = false;
             if (values != null) {
             	for (String type : values) {
-            		if (type.equals("cristalentity"))
-                        return item;
-                    else if (type.equals("cristalagent"))
+            		if (type.equals("cristalentity"))                        
+                        isItem = true;
+                    else if (type.equals("cristalagent"))                        
                         return new AgentPath(item);
             	}
             }
-            throw new ObjectNotFoundException("Not an entity '"+uuid+"'");
+            if (isItem) return item;
+            else throw new ObjectNotFoundException("Not an entity '"+uuid+"'");
 
         } catch (LDAPException ex) {
             if (ex.getResultCode() == LDAPException.NO_SUCH_OBJECT)

--- a/src/main/java/org/cristalise/lookup/ldap/LDAPLookup.java
+++ b/src/main/java/org/cristalise/lookup/ldap/LDAPLookup.java
@@ -435,13 +435,16 @@ public class LDAPLookup implements LookupManager{
         try {
         	ItemPath item = new ItemPath(uuid);
             LDAPEntry anEntry=mLDAPAuth.getAuthObject().read(getDN(item)+mLocalPath,attr);
-            String type = LDAPLookupUtils.getFirstAttributeValue(anEntry, "objectClass");
-            if (type.equals("cristalentity"))
-                return item;
-            else if (type.equals("cristalagent"))
-                return new AgentPath(item);
-            else
-                throw new ObjectNotFoundException("Not an entity '"+uuid+"'");
+            String[] values = LDAPLookupUtils.getAllAttributeValues(anEntry, "objectclass");
+            if (values != null) {
+            	for (String type : values) {
+            		if (type.equals("cristalentity"))
+                        return item;
+                    else if (type.equals("cristalagent"))
+                        return new AgentPath(item);
+            	}
+            }
+            throw new ObjectNotFoundException("Not an entity '"+uuid+"'");
 
         } catch (LDAPException ex) {
             if (ex.getResultCode() == LDAPException.NO_SUCH_OBJECT)


### PR DESCRIPTION
On Apache DS (LDAP), "objectclass" attribute of an item can have more that one value. We should iterate on all values to retrieve either "cristalentity" or "cristalagent" values.
